### PR TITLE
fix: Correct npm install execution directory in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -458,7 +458,7 @@ def main():
         print_color("Python dependencies installation complete.", Colors.OKGREEN)
 
         print_color("\nInstalling frontend Node.js dependencies from frontend/package.json. This can also take some time...", Colors.OKBLUE)
-        run_command([npm_executable_path, "install", "--prefix", "frontend"], stream_output=True, cwd=".")
+        run_command([npm_executable_path, "install"], stream_output=True, cwd="frontend")
         print_color("Frontend dependencies installation complete.", Colors.OKGREEN)
 
         if global_config.get("SETUP_MODE") == "local":


### PR DESCRIPTION
Modifies `setup.py` to fix an error where `npm install` for frontend dependencies failed because it could not find the `package.json` file.

The `run_command` call for `npm install` has been changed:
- The `--prefix frontend` argument has been removed.
- The `cwd` (current working directory) for the command has been set to `"frontend"`.

This ensures that `npm install` is executed from within the `frontend` directory, allowing it to correctly locate and process `frontend/package.json`. This resolves the `ENOENT D:\Blinker\Blinker\package.json` error.