### PR TITLE
Fix: Ensure mise commands are invoked via system PATH

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -257,11 +257,10 @@ def check_docker():
 def check_mise():
     print_color("\n--- Step 2: Checking Mise ---", Colors.HEADER)
     print_color("Mise manages project-specific CLI versions.", Colors.OKCYAN)
-    mise_executable_path = os.path.expanduser("~/.local/bin/mise")
-    if os.path.exists(mise_executable_path):
-        print_color(f"Mise found at {mise_executable_path}.", Colors.OKGREEN)
+    if shutil.which("mise"):
+        print_color("Mise found.", Colors.OKGREEN)
         return True
-    print_color(f"Mise not found at {mise_executable_path}.", Colors.WARNING)
+    print_color("Mise not found.", Colors.WARNING)
     return False
 
 
@@ -514,16 +513,14 @@ def main():
 
         print_color("\nEnsuring correct tool versions with Mise. This might take a few moments...", Colors.OKBLUE)
         print_color("DEBUG: About to run mise install...", Colors.WARNING)
-        mise_executable_path = os.path.expanduser("~/.local/bin/mise")
-        run_command([mise_executable_path, "install"], stream_output=True)
+        run_command(["mise", "install"], stream_output=True)
         print_color("Mise tool versioning complete.", Colors.OKGREEN)
 
         print_color("\n--- Locating npm via mise ---", Colors.HEADER)
         npm_executable_path = ""
         try:
-            mise_executable_path = os.path.expanduser("~/.local/bin/mise")
             mise_which_result = run_command(
-                [mise_executable_path, "which", "npm"],
+                ["mise", "which", "npm"],
                 capture_output_default=True,
                 text_default=True,
                 check=False


### PR DESCRIPTION
This commit ensures that `setup.py` consistently calls the `mise` executable using the command "mise" (e.g., `["mise", "install"]`), relying on the system's PATH for resolution.

This was verified by:
- Reviewing all `run_command` calls for `mise` in the `main()` function to ensure they use the literal "mise".
- Confirming the `check_mise()` function uses `shutil.which("mise")` to correctly detect `mise` if it's in the PATH.
- The `install_mise()` function for Windows was also improved in a previous commit to use `where mise` to verify installation and signal availability, complementing the PATH-based execution.

This approach should prevent issues where `mise` might be called with an incorrect or hardcoded path. If the `mise` executable is correctly installed and its location is added to the system PATH (as is typical for installations via `winget` or standard `mise` installers), `setup.py` will now reliably use it.