### PR TITLE
Fix: Provide Supabase env vars to frontend build in Docker

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -80,6 +80,9 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      args: # Add this section
+        - NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL}
+        - NEXT_PUBLIC_SUPABASE_ANON_KEY=${NEXT_PUBLIC_SUPABASE_ANON_KEY}
     ports:
       - "3000:3000"
     # volumes:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -24,6 +24,14 @@ RUN npm install
 # Copy the frontend code
 COPY . .
 
+# Declare build arguments
+ARG NEXT_PUBLIC_SUPABASE_URL
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+# Set environment variables from build arguments
+ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL
+ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY
+
 ENV NEXT_PUBLIC_VERCEL_ENV production
 
 RUN npm run build


### PR DESCRIPTION
The Next.js frontend build was failing during `docker-compose build` because it lacked access to essential Supabase environment variables (NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY) needed for prerendering pages (e.g., /legal).

This commit addresses the issue by:
1.  Modifying `docker-compose.yaml`:
    - The `frontend` service definition now includes a `build.args` section. These arguments take their values from the .env file (e.g., `NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL}`), passing them into the Docker build process.

2.  Modifying `frontend/Dockerfile`:
    - Added `ARG` declarations for `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`.
    - Set these as environment variables using `ENV` directives (e.g., `ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL`) before the `RUN npm run build` command.

These changes ensure that the required environment variables are available to the Next.js build system when executed within Docker, allowing the build to complete successfully.