### PR TITLE
Fix: Ensure clean NEXT_PUBLIC_API_URL build arg in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -80,15 +80,15 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
-      args: # Add this section
+      args:
         - NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL}
         - NEXT_PUBLIC_SUPABASE_ANON_KEY=${NEXT_PUBLIC_SUPABASE_ANON_KEY}
-        - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL} # Add this line
+        - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
     ports:
       - "3000:3000"
     # volumes:
       # - ./frontend/.env.local:/app/.env.local:ro # Removed
-    env_file: # Added to load root .env
+    env_file:
       - .env
     environment:
       - NODE_ENV=production


### PR DESCRIPTION
This commit refines the `docker-compose.yaml` configuration for your frontend service to ensure the `NEXT_PUBLIC_API_URL` build argument is cleanly defined.

Previously, a trailing comment on the line defining this build argument might have interfered with Docker Compose's variable interpolation or parsing. This comment has been removed.

- `- NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}` in `frontend.build.args` is now confirmed to be free of any extraneous characters.

This change, combined with the existing correct setup in `frontend/Dockerfile` (declaring the ARG and setting the ENV) and the generation of `NEXT_PUBLIC_API_URL` in your .env file by `setup.py`, should robustly ensure that the variable is available to the Next.js build process, resolving issues related to URL parsing when the API URL was previously unavailable.