### PR TITLE
Fix: Use NEXT_PUBLIC_API_URL for feature flags in frontend

### DIFF
--- a/frontend/src/lib/feature-flags.ts
+++ b/frontend/src/lib/feature-flags.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const API_URL = process.env.NEXT_PUBLIC_BACKEND_URL || '';
+const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
 
 export interface FeatureFlag {
   flag_name: string;


### PR DESCRIPTION
The frontend build was failing with a "TypeError: Failed to parse URL" when trying to fetch feature flags (e.g., /feature-flags/agent_marketplace). This was because `frontend/src/lib/feature-flags.ts` was attempting to use `process.env.NEXT_PUBLIC_BACKEND_URL` to construct the API endpoint. However, the build environment is configured to provide `process.env.NEXT_PUBLIC_API_URL` for this purpose.

This commit updates `frontend/src/lib/feature-flags.ts` to use `process.env.NEXT_PUBLIC_API_URL` when defining the base URL for feature flag API calls. This aligns the frontend code with the established environment variable configuration, ensuring that correct absolute URLs are used for these API requests during the Next.js build process (static site generation).

This change should resolve the URL parsing errors and allow the frontend build to complete successfully with respect to feature flag fetching.