### PR TITLE
Fix: Add SUPABASE_URL to .env for backend configuration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -494,6 +494,7 @@ def main():
 
         print_color("\n--- Generating .env file ---", Colors.HEADER)
         env_vars = {
+            "SUPABASE_URL": global_config.get('SUPABASE_URL'), # Add this line
             "NEXT_PUBLIC_SUPABASE_URL": global_config.get('SUPABASE_URL'),
             "NEXT_PUBLIC_SUPABASE_ANON_KEY": global_config.get('SUPABASE_ANON_KEY'),
             "SUPABASE_SERVICE_ROLE_KEY": global_config.get('SUPABASE_SERVICE_ROLE_KEY'),


### PR DESCRIPTION
The backend service was failing to start with an AttributeError because the `SUPABASE_URL` environment variable was missing. The Configuration class in the backend expected this variable to be set.

This commit updates the `.env` generation logic in `setup.py` to include `SUPABASE_URL`. Its value is sourced from the same configuration entry (`global_config.get('SUPABASE_URL')`) that is used for `NEXT_PUBLIC_SUPABASE_URL` (for the frontend).

This ensures that the backend container, which loads the .env file via `docker-compose.yaml`, receives the necessary `SUPABASE_URL` environment variable, allowing its configuration to initialize correctly and preventing the startup error.