### PR TITLE
Fix: Ensure all backend Supabase keys are in .env

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -494,10 +494,11 @@ def main():
 
         print_color("\n--- Generating .env file ---", Colors.HEADER)
         env_vars = {
-            "SUPABASE_URL": global_config.get('SUPABASE_URL'), # Add this line
+            "SUPABASE_URL": global_config.get('SUPABASE_URL'),
+            "SUPABASE_ANON_KEY": global_config.get('SUPABASE_ANON_KEY'),
+            "SUPABASE_SERVICE_ROLE_KEY": global_config.get('SUPABASE_SERVICE_ROLE_KEY'),
             "NEXT_PUBLIC_SUPABASE_URL": global_config.get('SUPABASE_URL'),
             "NEXT_PUBLIC_SUPABASE_ANON_KEY": global_config.get('SUPABASE_ANON_KEY'),
-            "SUPABASE_SERVICE_ROLE_KEY": global_config.get('SUPABASE_SERVICE_ROLE_KEY'),
             "BLINKER_SETUP_MODE": global_config.get('SETUP_MODE')
         }
         if global_config.get("SETUP_MODE") == "local":


### PR DESCRIPTION
The backend service was failing to start due to missing Supabase configuration environment variables. Initially, `SUPABASE_URL` was missing, and subsequently `SUPABASE_ANON_KEY` was also found to be absent from the backend's runtime environment.

The backend's `Configuration` class expects `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `SUPABASE_SERVICE_ROLE_KEY` to be set.

This commit updates the `.env` generation logic in `setup.py` to explicitly include all three of these backend-specific Supabase variables, sourcing their values from your global configuration:
- SUPABASE_URL (from global_config.get('SUPABASE_URL'))
- SUPABASE_ANON_KEY (from global_config.get('SUPABASE_ANON_KEY'))
- SUPABASE_SERVICE_ROLE_KEY (from global_config.get('SUPABASE_SERVICE_ROLE_KEY'))

These are added alongside the existing `NEXT_PUBLIC_` versions of these keys which are used by the frontend.

This ensures that the backend container, loading environment variables from the .env file via `docker-compose.yaml`, receives all necessary Supabase configuration, allowing it to initialize and start correctly.