### PR TITLE
Fix: Proactively ensure all backend env vars are configured

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -478,10 +478,19 @@ def main():
                 k_info['default_local'] = None  # No defaults for Daytona
         gestionar_grupo_config("Supabase", supabase_keys_info_updated, global_config, current_setup_mode)
 
+        daytona_keys_info = [
+            {"clave": "DAYTONA_API_KEY", "descripcion": "Daytona API Key", "es_secreto": True, "default_local": None, "default_daytona": None},
+            {"clave": "DAYTONA_SERVER_URL", "descripcion": "Daytona Server URL", "es_secreto": False, "default_local": None, "default_daytona": None},
+            {"clave": "DAYTONA_TARGET", "descripcion": "Daytona Target", "es_secreto": False, "default_local": None, "default_daytona": None}
+        ]
+        gestionar_grupo_config("Daytona", daytona_keys_info, global_config, current_setup_mode)
+
         print_color("\n--- Optional API Keys ---", Colors.HEADER)
         tools_api_keys = [
             {"name": "Zillow", "key": "RAPIDAPI_KEY_ZILLOW", "desc": "RapidAPI Key for Zillow"},
-            {"name": "Twitter", "key": "TWITTER_API_KEY", "desc": "Twitter API Key"}
+            {"name": "Twitter", "key": "TWITTER_API_KEY", "desc": "Twitter API Key"},
+            {"name": "Tavily", "key": "TAVILY_API_KEY", "desc": "Tavily API Key"},
+            {"name": "Firecrawl", "key": "FIRECRAWL_API_KEY", "desc": "Firecrawl API Key"}
         ]
         for tool_spec in tools_api_keys:
             prompt = f"Configure {tool_spec['name']} API Key? (Y/n): "
@@ -499,10 +508,20 @@ def main():
             "SUPABASE_SERVICE_ROLE_KEY": global_config.get('SUPABASE_SERVICE_ROLE_KEY'),
             "NEXT_PUBLIC_SUPABASE_URL": global_config.get('SUPABASE_URL'),
             "NEXT_PUBLIC_SUPABASE_ANON_KEY": global_config.get('SUPABASE_ANON_KEY'),
-            "BLINKER_SETUP_MODE": global_config.get('SETUP_MODE')
+            "BLINKER_SETUP_MODE": global_config.get('SETUP_MODE'),
+            "DAYTONA_API_KEY": global_config.get('DAYTONA_API_KEY'),
+            "DAYTONA_SERVER_URL": global_config.get('DAYTONA_SERVER_URL'),
+            "DAYTONA_TARGET": global_config.get('DAYTONA_TARGET'),
         }
+
+        if global_config.get('RAPIDAPI_KEY_ZILLOW'):
+            env_vars['RAPID_API_KEY'] = global_config.get('RAPIDAPI_KEY_ZILLOW')
+
         if global_config.get("SETUP_MODE") == "local":
             env_vars["NEXT_PUBLIC_API_URL"] = "http://localhost:8000"
+            env_vars["REDIS_HOST"] = "redis"
+            env_vars["REDIS_PASSWORD"] = ""
+
         for tool_spec in tools_api_keys:
             if tool_spec['key'] in global_config:
                 env_vars[tool_spec['key']] = global_config[tool_spec['key']]


### PR DESCRIPTION
This commit comprehensively updates `setup.py` to ensure all known mandatory environment variables required by the backend service are configured by you and included in the generated .env file. This addresses previous iterative fixes for missing variables like SUPABASE_URL, SUPABASE_ANON_KEY, and DAYTONA_API_KEY.

Changes:
1.  I reviewed `backend/utils/config.py` to identify all non-optional environment variables required by the `Configuration` class.
2.  I added new prompts in `setup.py` for configurations that were previously missing:
    - Daytona: DAYTONA_API_KEY, DAYTONA_SERVER_URL, DAYTONA_TARGET
    - Other services: TAVILY_API_KEY, FIRECRAWL_API_KEY
3.  I updated the `.env` file generation logic in `setup.py` to ensure all identified mandatory backend variables are included:
    - SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY
    - REDIS_HOST, REDIS_PASSWORD (for local Docker setup)
    - DAYTONA_API_KEY, DAYTONA_SERVER_URL, DAYTONA_TARGET
    - TAVILY_API_KEY
    - RAPID_API_KEY (mapped from the RAPIDAPI_KEY_ZILLOW prompt)
    - FIRECRAWL_API_KEY

This proactive approach aims to prevent further `AttributeError` exceptions during backend startup due to missing environment variables, making the setup process more robust.