### PR TITLE
Fix: Conditionally prompt and set Daytona config based on mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -483,7 +483,8 @@ def main():
             {"clave": "DAYTONA_SERVER_URL", "descripcion": "Daytona Server URL", "es_secreto": False, "default_local": None, "default_daytona": None},
             {"clave": "DAYTONA_TARGET", "descripcion": "Daytona Target", "es_secreto": False, "default_local": None, "default_daytona": None}
         ]
-        gestionar_grupo_config("Daytona", daytona_keys_info, global_config, current_setup_mode)
+        if current_setup_mode == "daytona":
+            gestionar_grupo_config("Daytona", daytona_keys_info, global_config, current_setup_mode)
 
         print_color("\n--- Optional API Keys ---", Colors.HEADER)
         tools_api_keys = [
@@ -509,15 +510,27 @@ def main():
             "NEXT_PUBLIC_SUPABASE_URL": global_config.get('SUPABASE_URL'),
             "NEXT_PUBLIC_SUPABASE_ANON_KEY": global_config.get('SUPABASE_ANON_KEY'),
             "BLINKER_SETUP_MODE": global_config.get('SETUP_MODE'),
-            "DAYTONA_API_KEY": global_config.get('DAYTONA_API_KEY'),
-            "DAYTONA_SERVER_URL": global_config.get('DAYTONA_SERVER_URL'),
-            "DAYTONA_TARGET": global_config.get('DAYTONA_TARGET'),
+            "DAYTONA_API_KEY": global_config.get('DAYTONA_API_KEY'), # Included here, might be None if not Daytona mode
+            "DAYTONA_SERVER_URL": global_config.get('DAYTONA_SERVER_URL'), # Included here
+            "DAYTONA_TARGET": global_config.get('DAYTONA_TARGET'), # Included here
         }
+
+        if current_setup_mode == "daytona":
+            # These are already included above, this block ensures they are sourced if daytona mode
+            # and potentially allows for specific daytona-mode modifications if needed in the future.
+            # For now, it's redundant with the above but matches the requested logic structure.
+            env_vars["DAYTONA_API_KEY"] = global_config.get('DAYTONA_API_KEY')
+            env_vars["DAYTONA_SERVER_URL"] = global_config.get('DAYTONA_SERVER_URL')
+            env_vars["DAYTONA_TARGET"] = global_config.get('DAYTONA_TARGET')
+        elif current_setup_mode == "local":
+            env_vars["DAYTONA_API_KEY"] = ""  # Empty string for local mode
+            env_vars["DAYTONA_SERVER_URL"] = "" # Empty string for local mode
+            env_vars["DAYTONA_TARGET"] = ""   # Empty string for local mode
 
         if global_config.get('RAPIDAPI_KEY_ZILLOW'):
             env_vars['RAPID_API_KEY'] = global_config.get('RAPIDAPI_KEY_ZILLOW')
 
-        if global_config.get("SETUP_MODE") == "local":
+        if global_config.get("SETUP_MODE") == "local": # This is current_setup_mode
             env_vars["NEXT_PUBLIC_API_URL"] = "http://localhost:8000"
             env_vars["REDIS_HOST"] = "redis"
             env_vars["REDIS_PASSWORD"] = ""


### PR DESCRIPTION
This commit refines the handling of Daytona-specific configurations (DAYTONA_API_KEY, DAYTONA_SERVER_URL, DAYTONA_TARGET) in `setup.py` based on your feedback.

Changes:
1.  Daytona configuration prompts:
    - You are now only prompted for Daytona-specific details if you select the "daytona" setup mode. Users selecting "local" mode will no longer see these irrelevant prompts.

2.  .env file generation for Daytona keys:
    - If "daytona" mode is selected, the `.env` file will be populated with the Daytona keys using the values provided by you (or loaded from `.blinker_config`).
    - If "local" mode is selected, `DAYTONA_API_KEY`, `DAYTONA_SERVER_URL`, and `DAYTONA_TARGET` will be set to empty strings ("") in the `.env` file. This ensures that the backend, which currently expects these variables to be defined unconditionally, does not raise an AttributeError during startup, while still not requiring local-mode users to provide actual Daytona credentials.

This improves the user experience for local setups and ensures the backend receives the Daytona-related environment variables in a way that satisfies its current validation logic across different modes.