### PR TITLE
Fix: Ensure .env completeness and improve secret visibility in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -345,7 +345,7 @@ def gestionar_config(clave: str, descripcion: str, es_secreto: bool,
                      ask_use_saved: bool = True) -> str:
     valor_actual = current_config.get(clave)
     if ask_use_saved and valor_actual is not None:
-        display_val = '(hidden)' if es_secreto else f"'{valor_actual}'"
+        display_val = f"'{valor_actual}'" # Changed here
         prompt_text = f"Saved value for {descripcion} ({display_val}). Use it? (Y/n): "
         if input_color(prompt_text, Colors.WARNING).strip().lower() in ['y', '']:
             return valor_actual
@@ -511,26 +511,30 @@ def main():
             "NEXT_PUBLIC_SUPABASE_ANON_KEY": global_config.get('SUPABASE_ANON_KEY'),
             "BLINKER_SETUP_MODE": global_config.get('SETUP_MODE'),
             "DAYTONA_API_KEY": global_config.get('DAYTONA_API_KEY'), # Included here, might be None if not Daytona mode
-            "DAYTONA_SERVER_URL": global_config.get('DAYTONA_SERVER_URL'), # Included here
-            "DAYTONA_TARGET": global_config.get('DAYTONA_TARGET'), # Included here
+            "DAYTONA_API_KEY": global_config.get('DAYTONA_API_KEY'),
+            "DAYTONA_SERVER_URL": global_config.get('DAYTONA_SERVER_URL'),
+            "DAYTONA_TARGET": global_config.get('DAYTONA_TARGET'),
         }
 
         if current_setup_mode == "daytona":
-            # These are already included above, this block ensures they are sourced if daytona mode
-            # and potentially allows for specific daytona-mode modifications if needed in the future.
-            # For now, it's redundant with the above but matches the requested logic structure.
             env_vars["DAYTONA_API_KEY"] = global_config.get('DAYTONA_API_KEY')
             env_vars["DAYTONA_SERVER_URL"] = global_config.get('DAYTONA_SERVER_URL')
             env_vars["DAYTONA_TARGET"] = global_config.get('DAYTONA_TARGET')
         elif current_setup_mode == "local":
-            env_vars["DAYTONA_API_KEY"] = ""  # Empty string for local mode
-            env_vars["DAYTONA_SERVER_URL"] = "" # Empty string for local mode
-            env_vars["DAYTONA_TARGET"] = ""   # Empty string for local mode
+            env_vars["DAYTONA_API_KEY"] = ""
+            env_vars["DAYTONA_SERVER_URL"] = ""
+            env_vars["DAYTONA_TARGET"] = ""
 
-        if global_config.get('RAPIDAPI_KEY_ZILLOW'):
-            env_vars['RAPID_API_KEY'] = global_config.get('RAPIDAPI_KEY_ZILLOW')
+        rapid_api_zillow_val = global_config.get('RAPIDAPI_KEY_ZILLOW')
+        env_vars['RAPID_API_KEY'] = rapid_api_zillow_val if rapid_api_zillow_val is not None else ""
 
-        if global_config.get("SETUP_MODE") == "local": # This is current_setup_mode
+        tavily_api_key_val = global_config.get('TAVILY_API_KEY')
+        env_vars['TAVILY_API_KEY'] = tavily_api_key_val if tavily_api_key_val is not None else ""
+
+        firecrawl_api_key_val = global_config.get('FIRECRAWL_API_KEY')
+        env_vars['FIRECRAWL_API_KEY'] = firecrawl_api_key_val if firecrawl_api_key_val is not None else ""
+
+        if global_config.get("SETUP_MODE") == "local":
             env_vars["NEXT_PUBLIC_API_URL"] = "http://localhost:8000"
             env_vars["REDIS_HOST"] = "redis"
             env_vars["REDIS_PASSWORD"] = ""


### PR DESCRIPTION
This commit addresses two key areas in `setup.py` based on your feedback:

1.  Robust .env generation for mandatory backend API keys:
    - Keys like `TAVILY_API_KEY`, `FIRECRAWL_API_KEY`, and `RAPID_API_KEY` (mapped from `RAPIDAPI_KEY_ZILLOW`) are declared as non-optional strings in the backend configuration (`backend/utils/config.py`).
    - Previously, if you skipped the 'optional' prompts for these keys in `setup.py`, the keys might have been omitted from the generated .env file, leading to AttributeErrors during backend startup.
    - This change ensures that these specific keys are always included in the .env file. If you do not provide a value when prompted (or if the source configuration is missing), these keys will default to an empty string (e.g., `TAVILY_API_KEY=""`). This satisfies the backend's requirement for the keys to be present (an empty string is not None).

2.  Display saved secret values in setup prompts:
    - The `gestionar_config` function, when prompting you to reuse a saved configuration value, previously showed "(hidden)" for values marked as secrets (e.g., API keys, passwords).
    - Per your request for better visibility during your local setup, this has been changed to display the actual saved value in the prompt (e.g., "Saved value for Supabase Service Role Key ('your_actual_key'). Use it? (Y/n):").
    - The input of *new* secret values remains hidden using `getpass`.

These changes aim to make the setup process more robust by preventing backend startup errors due to missing (but mandatory) configurations and to improve your experience by providing more transparency for saved values during interactive setup.