### PR TITLE
Alright, I've made a fix to address an `ImportError`.

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -55,7 +55,7 @@ pika = "^1.3.2"
 prometheus-client = "^0.21.1"
 langfuse = "^2.60.5"
 Pillow = "^10.0.0"
-mcp = "^1.0.0"
+mcp = {version = "^1.0.0", extras = ["cli"]}
 sentry-sdk = {extras = ["fastapi"], version = "^2.29.1"}
 httpx = "^0.28.0"
 aiohttp = "^3.9.0"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 python-dotenv==1.0.1
 litellm==1.66.1
-mcp~=1.0.0
+mcp[cli]~=1.0.0
 click==8.1.7
 questionary==2.0.1
 requests>=2.31.0


### PR DESCRIPTION
It seems the `mcp` package needed its `[cli]` extras to be installed. This was causing an issue with `streamablehttp_client` within `mcp_local/client.py`.

Here's what I changed:
- In `pyproject.toml`, I updated the `mcp` dependency to `{version = "^1.0.0", extras = ["cli"]}`.
- In `requirements.txt`, I changed `mcp` to `mcp[cli]~=1.0.0`.

These changes should ensure that all the necessary components, like `streamablehttp_client`, are installed correctly with the `mcp` package.