### PR TITLE
Fix: Add fallback import path for streamablehttp_client in mcp_local

### DIFF
--- a/backend/mcp_local/client.py
+++ b/backend/mcp_local/client.py
@@ -22,10 +22,14 @@ except ImportError:
     try:
         from mcp.client import streamablehttp_client
     except ImportError:
-        raise ImportError(
-            "Could not import streamablehttp_client. "
-            "Make sure you have installed mcp with: pip install 'mcp[cli]'"
-        )
+        try:
+            # Third attempt: directly from mcp
+            from mcp import streamablehttp_client
+        except ImportError:
+            raise ImportError(
+                "Could not import streamablehttp_client from common locations (mcp.client.streamable_http, mcp.client, or mcp). "
+                "Make sure you have installed mcp with: pip install 'mcp[cli]' and that the 'streamablehttp_client' is available in one of these paths for the installed mcp version."
+            )
 
 # Import types - these should be in mcp.types according to the docs
 try:


### PR DESCRIPTION
This commit adds an additional fallback import attempt for `streamablehttp_client` within `backend/mcp_local/client.py`.

Even after specifying `mcp[cli]~=1.0.0` in dependencies, an ImportError for `streamablehttp_client` persisted. The original code attempted to import it from `mcp.client.streamable_http` and then from `mcp.client`.

This change adds a third attempt: `from mcp import streamablehttp_client`. The final ImportError message has also been updated to reflect all paths tried. This is an attempt to locate the module if its path has changed in `mcp version 1.0.0`.