### PR TITLE
Fix: Resolve ModuleNotFoundError for models.mcp

### DIFF
--- a/backend/models/mcp.py
+++ b/backend/models/mcp.py
@@ -1,0 +1,8 @@
+from typing import List, Dict, Any, Optional
+from pydantic import BaseModel
+
+class McpConfig(BaseModel):
+    qualifiedName: str
+    name: str
+    config: Dict[str, Any]
+    enabledTools: Optional[List[str]] = None


### PR DESCRIPTION
I created the `McpConfig` Pydantic model in `backend/models/mcp.py` and added `backend/models/__init__.py` to make the `models` directory a Python package.

This resolves the `ModuleNotFoundError: No module named 'models'` that occurred in `backend/agent/tools/mcp_tool_wrapper.py` when trying to import `McpConfig`. The `McpConfig` model definition is based on its usage within the MCP client and tool wrapper.