### PR TITLE
Enhance warnings for missing API keys and credentials

### DIFF
--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -13,7 +13,7 @@ class EmailService:
         self.sender_name = os.getenv('MAILTRAP_SENDER_NAME', 'Suna Team')
         
         if not self.api_token:
-            logger.warning("MAILTRAP_API_TOKEN not found in environment variables")
+            logger.warning("MAILTRAP_API_TOKEN not found in environment variables. Email services will be disabled. Please configure it in your .env file (you can use backend/.env.example as a template).")
             self.client = None
         else:
             self.client = mt.MailtrapClient(token=self.api_token)

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -43,7 +43,7 @@ def setup_api_keys() -> None:
         if key:
             logger.debug(f"API key set for provider: {provider}")
         else:
-            logger.warning(f"No API key found for provider: {provider}")
+            logger.warning(f"No API key found for provider: {provider}. Functionality requiring this provider will be disabled. Please configure it in your .env file (you can use backend/.env.example as a template).")
 
     # Set up OpenRouter API base if not already set
     if config.OPENROUTER_API_KEY and config.OPENROUTER_API_BASE:
@@ -62,7 +62,7 @@ def setup_api_keys() -> None:
         os.environ['AWS_SECRET_ACCESS_KEY'] = aws_secret_key
         os.environ['AWS_REGION_NAME'] = aws_region
     else:
-        logger.warning(f"Missing AWS credentials for Bedrock integration - access_key: {bool(aws_access_key)}, secret_key: {bool(aws_secret_key)}, region: {aws_region}")
+        logger.warning(f"Missing AWS credentials for Bedrock integration (access_key: {bool(aws_access_key)}, secret_key: {bool(aws_secret_key)}, region: {aws_region}). Bedrock functionality will be disabled. Please configure these in your .env file (you can use backend/.env.example as a template).")
 
 async def handle_error(error: Exception, attempt: int, max_attempts: int) -> None:
     """Handle API errors with appropriate delays and logging."""


### PR DESCRIPTION
I updated the warning messages in `backend/services/email.py` and `backend/services/llm.py` to be more informative when API keys or AWS credentials are not found in the environment.

The new messages now:
- Clearly state which service or functionality will be disabled due to the missing key/credential.
- Guide you to the `backend/.env.example` file for instructions on how to configure the necessary environment variables.

This change aims to improve your experience by providing actionable feedback when the application starts with incomplete optional configurations.