### PR TITLE
Add debug print statements for startup diagnostics

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1,3 +1,4 @@
+print("DEBUG: backend.api.py - Top-level execution started")
 import sys, os
 # Esto añade el directorio raíz del proyecto a la ruta de búsqueda de Python
 # para solucionar los ModuleNotFoundError.
@@ -12,6 +13,7 @@ from services.supabase import DBConnection
 from datetime import datetime, timezone
 from dotenv import load_dotenv
 from utils.config import config, EnvMode
+print(f"DEBUG: backend.api.py - Imported config. ENV_MODE is {config.ENV_MODE.value if config else 'config_not_loaded'}")
 import asyncio
 from utils.logger import logger
 import time
@@ -43,8 +45,10 @@ instance_id = "single"
 ip_tracker = OrderedDict()
 MAX_CONCURRENT_IPS = 25
 
+print("DEBUG: backend.api.py - Lifespan function definition started")
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    print("DEBUG: backend.api.py - Lifespan async context manager entered")
     logger.info(f"Starting up FastAPI application with instance ID: {instance_id} in {config.ENV_MODE.value} mode")
     logger.info("--- Critical Backend Configuration ---")
     logger.info(f"ENV_MODE: {config.ENV_MODE.value}")
@@ -67,6 +71,7 @@ async def lifespan(app: FastAPI):
     logger.info(f"NEXT_PUBLIC_API_URL (from os.getenv): {next_public_api_url if next_public_api_url else '<Not Set in backend env>'}")
     logger.info("--- End of Critical Backend Configuration ---")
     try:
+        print("DEBUG: backend.api.py - Lifespan: About to await db.initialize()")
         await db.initialize()
         
         agent_api.initialize(
@@ -109,7 +114,9 @@ async def lifespan(app: FastAPI):
         logger.error(f"Error during application startup: {e}")
         raise
 
+print("DEBUG: backend.api.py - FastAPI app instantiation started")
 app = FastAPI(lifespan=lifespan)
+print("DEBUG: backend.api.py - FastAPI app instantiated")
 
 @app.middleware("http")
 async def log_requests_middleware(request: Request, call_next):

--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -176,6 +176,7 @@ class Configuration:
     
     def __init__(self):
         """Initialize configuration by loading from environment variables."""
+        print("DEBUG: backend.utils.config.Configuration.__init__ started")
         # Load environment variables from .env file if it exists
         load_dotenv()
         
@@ -187,6 +188,7 @@ class Configuration:
             logger.warning(f"Invalid ENV_MODE: {env_mode_str}, defaulting to LOCAL")
             self.ENV_MODE = EnvMode.LOCAL
             
+        print(f"DEBUG: backend.utils.config.Configuration - ENV_MODE determined as {self.ENV_MODE.value}")
         logger.info(f"Environment mode: {self.ENV_MODE.value}")
         
         # Load configuration from environment variables
@@ -235,6 +237,7 @@ class Configuration:
         
         if missing_fields:
             error_msg = f"Missing required configuration fields: {', '.join(missing_fields)}"
+            print(f"DEBUG: backend.utils.config.Configuration._validate - Raising ValueError: {error_msg}")
             logger.error(error_msg)
             raise ValueError(error_msg)
     


### PR DESCRIPTION
Introduces `print()` statements at critical early execution points in `backend/utils/config.py` and `backend/api.py`.

These changes are intended to:
- Trace the initialization sequence of the Configuration class and the FastAPI application.
- Help identify if the application is halting or failing before the standard logging mechanism is fully effective or if INFO logs are being suppressed.
- Diagnose why previously added `logger.info` calls in the FastAPI `lifespan` event were not appearing in your logs.

The print statements are prefixed with "DEBUG:" for easy identification in the console output. This will help pinpoint how far the application proceeds during startup.